### PR TITLE
Add example scripts that integrate akd with i3status

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,3 +53,11 @@ cmake --build .
 ```
 
 You will then get a binary named `akd`.
+
+## Tips
+
+### `i3bar` keyboard layout indicator
+
+You can use example scripts in `contrib/` directory to add a keyboard layout indicator to your `i3bar`, if you use `i3status` as the status generator. For more information on how they work refer to [i3status docs](https://i3wm.org/docs/i3status.html).
+
+Also, the scripts should be easily adaptable for other text-based status generators.

--- a/contrib/i3status-colored.sh
+++ b/contrib/i3status-colored.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+#
+# Extends i3status' output with 'akd -p' output. Supports colors.
+# Make sure to have output_format set to i3bar in i3status config's general
+# section.
+#
+# For indication to work correctly, edit your akd command here, don't start
+# another instance of akd.
+
+FORMAT=',[{"full_text":"%s"},%s\n'
+layout=''
+i3status=''
+
+{ i3status & sleep 0.5; akd -p
+} | while read -r line
+do
+    case "$line" in
+         ,\[{*) i3status=$line; printf "$FORMAT" "$layout" "${i3status#,\[}" ;;
+    [a-z][a-z]) layout=$line;   printf "$FORMAT" "$layout" "${i3status#,\[}" ;;
+          \[{*) i3status=,$line ;&
+             *) printf "%s\n" "$line" ;;
+    esac
+done
+
+pkill -P $$

--- a/contrib/i3status.sh
+++ b/contrib/i3status.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# 
+# Extends i3status' output with 'akd -p' output.
+# Make sure to have output_format unset in i3status' config or set to none.
+#
+# For indication to work correctly, edit your akd command here, don't start
+# another instance of akd.
+
+layout=''
+i3status=''
+
+{ i3status & akd -p
+} | while read -r line
+do
+    if [[ $line == [a-z][a-z] ]]; then
+        layout=$line
+    else
+        i3status=$line
+    fi
+    printf "%s | %s\n" "$layout" "$i3status"
+done
+
+pkill -P $$


### PR DESCRIPTION
Hi!

I wrote two scripts that allow `akd` to serve as a keyboard layout indicator in `i3bar`. The simple one extends plain text output of `i3status` and can probably be used with other text-based status bars (like `dwm`'s one). The colored one extends JSON output of `i3status` and allows to have color in `i3bar`, like with the default `i3status`.

The result is something like this:
![image](https://user-images.githubusercontent.com/35147577/112150343-a31a1080-8be8-11eb-9079-381e276f8548.png)
